### PR TITLE
Fix double cursor in Parkinson's simulation

### DIFF
--- a/src/simulations/parkinsons/content.js
+++ b/src/simulations/parkinsons/content.js
@@ -67,7 +67,7 @@ function start() {
   
   cursor = document.createElement('div');
 
-  cursor.style.background = `url(${cursorImgUrl})`
+  cursor.style.backgroundImage = `url(${cursorImgUrl})`
   cursor.setAttribute('id', 'wds-parkinsonsCursor');
 
   document.body.appendChild(cursor);

--- a/src/simulations/parkinsons/content.js
+++ b/src/simulations/parkinsons/content.js
@@ -28,7 +28,7 @@ function mousemoveHandler(e) {
   viewportPosX = e.clientX + offsetX;
   viewportPosY = e.clientY + offsetY;
 
-  setStyle(cursor, {left: cursorPosX + 'px', top: cursorPosY + 'px', transition: 'left 0.05s, top 0.05s'});
+  setStyle(cursor, {left: cursorPosX + 'px', top: cursorPosY + 'px'});
 }
 
 function elementClickHandler(e) {
@@ -60,15 +60,14 @@ function setOffset() {
 
 function start() {
 
-  let cursorImg = appVersion.includes('Mac') ? 'cursor_mac.svg' : 'cursor_windows.svg';
-  const cursorImgUrl = chrome.extension.getURL('/simulations/parkinsons/img/' + cursorImg);
+  const cursorType = appVersion.includes('Mac') ? 'mac' : 'windows';
 
   css = addCss(cssUrl);
   
   cursor = document.createElement('div');
 
-  cursor.style.backgroundImage = `url(${cursorImgUrl})`
   cursor.setAttribute('id', 'wds-parkinsonsCursor');
+  cursor.setAttribute('class', cursorType);
 
   document.body.appendChild(cursor);
   

--- a/src/simulations/parkinsons/content.js
+++ b/src/simulations/parkinsons/content.js
@@ -60,7 +60,7 @@ function setOffset() {
 
 function start() {
 
-  const cursorType = appVersion.includes('Mac') ? 'mac' : 'windows';
+  const cursorType = appVersion.includes('Windows') ? 'windows' : 'mac';
 
   css = addCss(cssUrl);
   

--- a/src/simulations/parkinsons/css/main.css
+++ b/src/simulations/parkinsons/css/main.css
@@ -8,4 +8,5 @@ body * {
 	width: 21px;
 	height: 21px; 
   pointer-events: none;
+  background-repeat: no-repeat;
 }

--- a/src/simulations/parkinsons/css/main.css
+++ b/src/simulations/parkinsons/css/main.css
@@ -8,5 +8,11 @@ body * {
 	width: 21px;
 	height: 21px; 
   pointer-events: none;
+  background-image: url("../img/cursor_windows.svg");
   background-repeat: no-repeat;
+  transition: left 0.05s, top 0.05s;
+}
+
+#wds-parkinsonsCursor.mac {
+  background-image: url("../img/cursor_mac.svg");
 }

--- a/src/simulations/parkinsons/css/main.css
+++ b/src/simulations/parkinsons/css/main.css
@@ -8,11 +8,11 @@ body * {
 	width: 21px;
 	height: 21px; 
   pointer-events: none;
-  background-image: url("../img/cursor_windows.svg");
+  background-image: url("../img/cursor_mac.svg");
   background-repeat: no-repeat;
   transition: left 0.05s, top 0.05s;
 }
 
-#wds-parkinsonsCursor.mac {
-  background-image: url("../img/cursor_mac.svg");
+#wds-parkinsonsCursor.windows {
+  background-image: url("../img/cursor_windows.svg");
 }


### PR DESCRIPTION
The Parkinson's simulation always shows two cursors. 
<img width="75" alt="" src="https://user-images.githubusercontent.com/108893/51396303-be83bf80-1b36-11e9-9679-0a2edbc3c031.png">

This fixes that to only use one.

While I was at it, I also moved all possible styles that were set via JS into the CSS file.
And I swapped the default cursor to be the Mac and not the Windows cursor. That way Chromebooks would get the correct cursor as well. (I guess Linux cursors are too diverse to try to find the best one for it.)

I can created separate PRs for these three different issues, if you prefer.

I've never worked on a Chrome extension, so only tested this in a local file.